### PR TITLE
Latest git release

### DIFF
--- a/.github/workflows/docker-registry-publish.yml
+++ b/.github/workflows/docker-registry-publish.yml
@@ -1,6 +1,7 @@
 name: Publish Docker image
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   push_docker:

--- a/.github/workflows/github-packages-publish.yml
+++ b/.github/workflows/github-packages-publish.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: ./Dockerfile.docker
-          tags: ghcr.io/msyea/ubuntu-docker:${{ env.GIT_SHORT_SHA }}
+          tags: ghcr.io/${{ github.repository_owner }}/ubuntu-docker:${{ env.GIT_SHORT_SHA }}
           push: true
   push_dind:
     needs: push_docker
@@ -38,15 +38,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker pull ghcr.io/msyea/ubuntu-docker:${{ env.GIT_SHORT_SHA }}
+      - run: docker pull ghcr.io/${{ github.repository_owner }}/ubuntu-docker:${{ env.GIT_SHORT_SHA }}
       - name: Push to GitHub
         uses: docker/build-push-action@v2
         with:
           file: ./Dockerfile.dind
-          tags: ghcr.io/msyea/ubuntu-dind:${{ env.GIT_SHORT_SHA }}
+          tags: ghcr.io/${{ github.repository_owner }}/ubuntu-dind:${{ env.GIT_SHORT_SHA }}
           push: true
           build-args: |
-            REGISTRY=ghcr.io/msyea
+            REGISTRY=ghcr.io/${{ github.repository_owner }}
             TAG=${{ env.GIT_SHORT_SHA }}
   push_gha:
     needs: [push_docker, push_dind]
@@ -63,12 +63,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker pull ghcr.io/msyea/ubuntu-dind:${{ env.GIT_SHORT_SHA }}
+      - run: docker pull ghcr.io/${{ github.repository_owner }}/ubuntu-dind:${{ env.GIT_SHORT_SHA }}
       - name: Push to GitHub
         uses: docker/build-push-action@v2
         with:
-          tags: ghcr.io/msyea/github-actions-runner:${{ env.GIT_SHORT_SHA }}
+          tags: ghcr.io/${{ github.repository_owner }}/github-actions-runner:${{ env.GIT_SHORT_SHA }}
           push: true
           build-args: |
-            REGISTRY=ghcr.io/msyea
+            REGISTRY=ghcr.io/${{ github.repository_owner }}
             TAG=${{ env.GIT_SHORT_SHA }}

--- a/.github/workflows/github-packages-publish.yml
+++ b/.github/workflows/github-packages-publish.yml
@@ -1,6 +1,7 @@
 name: Publish Docker image to GitHub
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   push_docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ RUN set -eux; \
 	echo 'rootless:100000:65536' >> /etc/subgid
 
 ENV DOCKER_CHANNEL=stable \
-  DOCKER_VERSION=20.10.6
+  DOCKER_VERSION=20.10.8
+
+# Ubuntu focal (20.04) has git v2.25, but GitHub Actions require higher. We
+# build git from source instead.
+ARG GIT_VERSION="2.29.0"
+ARG GH_RUNNER_VERSION="2.280.3"
 
 RUN set -eux; \
 	\
@@ -48,14 +53,32 @@ RUN set -eux; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
 
-RUN apt-get -y install jq curl
-RUN apt-get -y install awscli
+RUN apt-get update \
+		&& apt-get -y install \
+					jq \
+					curl \
+					awscli \
+					software-properties-common \
+					build-essential \
+					zlib1g-dev \
+					zstd \
+					gettext \
+		&& cd /tmp \
+		&& curl -sL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz -o git.tgz \
+		&& tar zxf git.tgz \
+		&& cd git-${GIT_VERSION} \
+		&& ./configure --prefix=/usr \
+		&& make \
+		&& make install \
+		&& rm -rf /var/lib/apt/lists/* \
+  	&& rm -rf /tmp/* \
+		&& git --version
 
 WORKDIR /actions-runner
 RUN chown rootless:rootless /actions-runner
 USER rootless
-RUN wget -O actions-runner-linux-x64-2.277.1.tar.gz https://github.com/actions/runner/releases/download/v2.277.1/actions-runner-linux-x64-2.277.1.tar.gz
-RUN tar xzf ./actions-runner-linux-x64-2.277.1.tar.gz
+RUN wget -O actions-runner-linux-x64-${GH_RUNNER_VERSION}.tar.gz https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-x64-${GH_RUNNER_VERSION}.tar.gz \
+		&& tar xzf ./actions-runner-linux-x64-${GH_RUNNER_VERSION}.tar.gz
 USER root
 RUN ./bin/installdependencies.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV DOCKER_CHANNEL=stable \
 # Ubuntu focal (20.04) has git v2.25, but GitHub Actions require higher. We
 # build git from source instead.
 ARG GIT_VERSION="2.33.0"
-ARG GH_RUNNER_VERSION="2.280.3"
+ARG GH_RUNNER_VERSION="2.282.1"
 
 # Root URL and version for Docker compose releases
 ARG COMPOSE_ROOT=https://github.com/docker/compose/releases/download

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ ENV DOCKER_CHANNEL=stable \
 ARG GIT_VERSION="2.33.0"
 ARG GH_RUNNER_VERSION="2.280.3"
 
+# Root URL and version for Docker compose releases
+ARG COMPOSE_ROOT=https://github.com/docker/compose/releases/download
+ARG COMPOSE_VERSION=1.29.2
+
 RUN set -eux; \
 	\
 	arch="$(uname --m)"; \
@@ -67,6 +71,9 @@ RUN apt-get update \
 					zstd \
 					gettext \
 					libcurl4-openssl-dev \
+		&& curl -L "${COMPOSE_ROOT%/}/${COMPOSE_VERSION#v*}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+		&& chmod a+x /usr/local/bin/docker-compose \
+		&& docker-compose --version \
 		&& cd /tmp \
 		&& curl -sL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz -o git.tgz \
 		&& tar zxf git.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV DOCKER_CHANNEL=stable \
 
 # Ubuntu focal (20.04) has git v2.25, but GitHub Actions require higher. We
 # build git from source instead.
-ARG GIT_VERSION="2.29.0"
+ARG GIT_VERSION="2.33.0"
 ARG GH_RUNNER_VERSION="2.280.3"
 
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update \
 					zlib1g-dev \
 					zstd \
 					gettext \
+					libcurl4-openssl-dev \
 		&& cd /tmp \
 		&& curl -sL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz -o git.tgz \
 		&& tar zxf git.tgz \

--- a/Dockerfile.docker
+++ b/Dockerfile.docker
@@ -16,7 +16,7 @@ RUN apt update \
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 
 ENV DOCKER_CHANNEL=stable \
-  DOCKER_VERSION=20.10.6
+  DOCKER_VERSION=20.10.8
 # TODO ENV DOCKER_SHA256
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)

--- a/github-actions-entrypoint.sh
+++ b/github-actions-entrypoint.sh
@@ -2,7 +2,7 @@
 source /opt/bash-utils/logger.sh
 
 function wait_for_process () {
-    local max_time_wait=30
+    local max_time_wait=${2:-30}
     local process_name="$1"
     local waited_sec=0
     while ! pgrep "$process_name" >/dev/null && ((waited_sec < max_time_wait)); do
@@ -24,7 +24,7 @@ INFO "Waiting for processes to be running"
 processes=(dockerd)
 
 for process in "${processes[@]}"; do
-    wait_for_process "$process"
+    wait_for_process "$process" 60
     if [ $? -ne 0 ]; then
         ERROR "$process is not running after max time"
         exit 1

--- a/github-actions-entrypoint.sh
+++ b/github-actions-entrypoint.sh
@@ -24,7 +24,7 @@ INFO "Waiting for processes to be running"
 processes=(dockerd)
 
 for process in "${processes[@]}"; do
-    wait_for_process "$process" 60
+    wait_for_process "$process"
     if [ $? -ne 0 ]; then
         ERROR "$process is not running after max time"
         exit 1


### PR DESCRIPTION
The gist of this PR is to be able to run with the latest release of `git` instead of the one that comes with Ubuntu 20.04. This is because minimum needed for GitHub Actions runners is v2.29, a version above the default package in Ubuntu 20.04. In more details, the PR:
+ Bumps up the version of `git` to the latest and makes it a build-time argument called `GIT_VERSION`
+ Bumps up the version of Docker to the latest in the `stable` channel
+ Bumps up the version of the GitHub runner to the latest and makes it a build-time argument called `GH_RUNNER_VERSION`.
+ Uses `${{ github.repository_owner }}` instead of the hard-coded `msyea` in the GHCR related workflow to facilitate forks. This will push images that are built to the forking account instead of the original, making testing easier.
+ Adds a way to manually run the workflows from the Web UI, without pushing.
+ Arranges for the directory structure accessible under $HOME/.local (for `rootless` user) is writable by the user. This is used by some build systems (e.g. [cake](https://cakebuild.net/)) to store dependencies and packages.